### PR TITLE
Fix will_java_throw_suppressed availability

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,15 +53,4 @@ AC_PATH_PROGS(JAR,jar,,[$javahome/bin])
 JARFLAGS=cvf
 AC_SUBST(JARFLAGS)
 
-JAVA_VER=(`"$JAVA" -version 2>&1 | awk 'BEGIN { FS="[[\".]]" } /^.*version "(.*)\.(.*)\.(.*)"/ { print $2, $3, $4 }'`)
-[echo "$JAVA"]
-[echo "Java version ${JAVA_VER[@]}"]
-[if test ${JAVA_VER[0]} -gt 1 -o ${JAVA_VER[1]} -gt 6; then]
-    AM_CONDITIONAL(JAVA_SUPPORTS_SUPPRESSED, true)
-    [echo "Java supports Suppressed exceptions"]
-[else]
-    AM_CONDITIONAL(JAVA_SUPPORTS_SUPPRESSED, false)
-    [echo "Java does NOT support Suppressed exceptions"]
-[fi]
-
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,11 +22,7 @@ WillJavaClassesdir = $(JAVADIR)
 WillJavaClasses_DATA = WillRaiseSigSegv.class
 
 WillJavaJarsdir = $(JARDIR)
-WillJavaJars_DATA = willremoteloader.jar willuncaught.jar
-
-if JAVA_SUPPORTS_SUPPRESSED
-WillJavaJars_DATA += willsuppressed.jar
-endif
+WillJavaJars_DATA = willremoteloader.jar willuncaught.jar willsuppressed.jar
 
 kmoddir = $(datarootdir)/@PACKAGE@/will_oops_kmod/
 kmod_DATA = will_oops_kmod/Makefile will_oops_kmod/will_oops.c
@@ -45,11 +41,8 @@ bin_SCRIPTS = will_python3_raise \
 			  will_java_segfault \
 			  will_oops \
 			  will_java_throw \
-			  will_java_throw_remote
-
-if JAVA_SUPPORTS_SUPPRESSED
-bin_SCRIPTS += will_java_throw_suppressed
-endif
+			  will_java_throw_remote \
+			  will_java_throw_suppressed
 
 will_java_segfault: will_java_segfault.in
 	sed -e s,\@JAVADIR\@,\"$(JAVADIR)\",g \
@@ -64,11 +57,9 @@ will_java_throw_remote: will_java_throw_remote.in
 		-e s,\@JARUNCAUGHT\@,\"$(JARDIR)/willuncaught.jar\",g \
 		will_java_throw_remote.in >will_java_throw_remote && chmod +x will_java_throw_remote
 
-if JAVA_SUPPORTS_SUPPRESSED
 will_java_throw_suppressed: will_java_throw_suppressed.in
 	sed -e s,\@JAR\@,\"`basename $(JARDIR)`/willsuppressed.jar\",g \
 		will_java_throw_suppressed.in >will_java_throw_suppressed && chmod +x will_java_throw_suppressed
-endif
 
 .java.class:
 	$(JAVAC) -Xlint:unchecked $<
@@ -79,20 +70,14 @@ willremoteloader.jar: WontCatchRemoteException.class
 willuncaught.jar: WontCatchNullPointerException.class
 	$(JAR) $(JARFLAGS) $@ $^ && rm -rf $^
 
-if JAVA_SUPPORTS_SUPPRESSED
 willsuppressed.jar: WontCatchSuppressedException.class
 	$(JAR) $(JARFLAGS) $@ $^ && rm -rf $^
-endif
 
 will_oops: will_oops.in
 	sed -e s,\@KMODSRC\@,\"$(kmoddir)\",g \
 		will_oops.in >will_oops && chmod +x will_oops
 
-ALL_TARGETS=will_java_segfault will_oops will_java_throw will_java_throw_remote
-
-if JAVA_SUPPORTS_SUPPRESSED
-ALL_TARGETS += will_java_throw_suppressed
-endif
+ALL_TARGETS=will_java_segfault will_oops will_java_throw will_java_throw_remote will_java_throw_suppressed
 
 all-local: $(ALL_TARGETS)
 
@@ -114,9 +99,6 @@ EXTRA_DIST = \
 	will_java_throw.in \
 	WontCatchNullPointerException.java \
 	will_java_throw_remote.in \
-	WontCatchRemoteException.java
-
-if JAVA_SUPPORTS_SUPPRESSED
-EXTRA_DIST += will_java_throw_suppressed.in
-EXTRA_DIST += WontCatchSuppressedException.java
-endif
+	WontCatchRemoteException.java \
+	will_java_throw_suppressed.in \
+	WontCatchSuppressedException.java

--- a/will-crash.spec.in
+++ b/will-crash.spec.in
@@ -60,9 +60,7 @@ find %{buildroot} -name '*.la' -or -name '*.a' | xargs rm -f
 %{_bindir}/will_java_segfault
 %{_bindir}/will_java_throw
 %{_bindir}/will_java_throw_remote
-%if 0%{?rhel} && 0%{?rhel} > 6
 %{_bindir}/will_java_throw_suppressed
-%endif
 %{_bindir}/will_cpp_segfault
 %{_bindir}/will_stackoverflow
 %{_bindir}/will_oops


### PR DESCRIPTION
Suppressed exceptions are supported since JDK7.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>