### PR TITLE
spec: Require perl-interpreter only

### DIFF
--- a/will-crash.spec
+++ b/will-crash.spec
@@ -21,7 +21,7 @@ BuildRequires:  ruby-devel
 
 Requires:       java-headless >= 1.7.0.0
 Requires:       javapackages-tools
-Requires:       perl
+Requires:       perl-interpreter
 Requires:       python3
 Requires:       ruby
 


### PR DESCRIPTION
Only the perl-interpreter is really required for `/usr/bin/perl`.

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>