### PR TITLE
Fix KMODSRC substitution

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -70,7 +70,7 @@ java_configuration_will_throw_suppressed = configuration_data()
 java_configuration_will_throw_suppressed.set_quoted('JAR', join_paths(jardir, 'willsuppressed.jar'))
 
 kmod_configuration = configuration_data()
-kmod_configuration.set_quoted('KMODSRC', kmoddir)
+kmod_configuration.set_quoted('KMODSRC', join_paths(prefix, kmoddir))
 
 generated_scripts = [
   {


### PR DESCRIPTION
Meson only prepends the prefix when a relative path is passed to
install_dir and friends, so we need to do it manually in this case.